### PR TITLE
Create before-pr command to see warnings clearly

### DIFF
--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -24,11 +24,6 @@ jobs:
 
     - name: npm clean install
       run: npm ci
-
-    - name: warn that warnings are ignored
-      run: echo "HEADS UP - this Action ignores warnings in builds. There may be issues deploying."
-      
+    
     - name: basic build
-      env: 
-        CI: false
       run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^16.18.57",
         "@types/react": "^18.2.24",
         "@types/react-dom": "^18.2.9",
+        "cross-env": "^7.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.16.0",
@@ -6249,6 +6250,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^16.18.57",
     "@types/react": "^18.2.24",
     "@types/react-dom": "^18.2.9",
+    "cross-env": "^7.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0",
@@ -23,7 +24,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "before-pr": "cross-env CI=true npm run build"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
When building a website to be deployed (aka published), React treats all warnings as errors. Common warnings include unused variables and unused imports.

I've created a command that we can run before we create a PR (Pull Request) that will list all warnings and allow us to rectify them before we create a PR.

**In the future, before creating a PR**, run the command `npm run before-pr`. If there are any warnings, you will see something like this:
\
![image](https://github.com/MrEminent42/casamico/assets/10686417/48be39aa-3783-4061-833e-95490ce1678b)
This means there is an unused variable at Page1.tsx on line 4. Remove it before continuing.

\
\
**Once you have fixed all warnings/errors**, you should see something like this:

\
![image](https://github.com/MrEminent42/casamico/assets/10686417/e69200cc-a779-44d9-bacb-e276995ddf08)


"Compiled successfully" is what you're looking for. \

**Please fix all warnings before creating a pull request! That way, Netlify will automatically publish the preview and we can have a live URL to the code that you've written.**