### PR TITLE
Add AddTask popup, some light cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/1" element={<Page1 />} />
-          <Route path="/property/:id" element={<Tasks />} />
+          <Route path="/property/:id/*" element={<Tasks />} />
         </Routes>
       </MainContainer>
     </FontWrapper>

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from 'react';
+import styled from 'styled-components'
+
+interface PopupProps {
+    element: JSX.Element;
+    onClickOutside?: () => any;
+    onKeyboardEsc?: () => any;
+}
+
+const Popup = (props: PopupProps) => {
+    const { onKeyboardEsc } = props;
+
+    // register a listener for the escape key
+    useEffect(() => {
+        const escPressHandler = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                onKeyboardEsc?.();
+            }
+        };
+
+        document.addEventListener('keydown', escPressHandler);
+
+        // when the page is unloaded, remove the listener
+        // (whatever is returned from useEffect is called when the component is unmounted)
+        return () => {
+            document.removeEventListener('keydown', escPressHandler);
+        };
+    }, [onKeyboardEsc]);
+
+
+    return (
+        <PopupWrapper>
+            <PopupBackdrop onClick={props.onClickOutside} />
+            <PopupContentsContainer children={props.element} />
+        </PopupWrapper>
+    )
+}
+
+export default Popup
+
+const PopupBackdrop = styled.div`
+    width: 100vw;
+    height: 100vh;
+    position: fixed;
+    top: 0;
+    left: 0;
+    background-color: rgba(0,0,0,.5);
+    opacity: 1;
+    z-index: 100;
+`
+
+const PopupWrapper = styled.div`
+    width: 100vw;
+    height: 100vh;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 101;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+`
+
+const PopupContentsContainer = styled.div`
+    max-width: 80vw;
+    max-height: 90vh;
+    background-color: white;
+    border-radius: 15px;
+    opacity: 1;
+    overflow: auto;
+    z-index: 102;
+`

--- a/src/controllers/PropertyController.tsx
+++ b/src/controllers/PropertyController.tsx
@@ -2,7 +2,6 @@ import { Property } from "../Types";
 import { supabase } from "../supabase/supabaseClient";
 
 export const getAllProperties = async () => {
-    alert("You have asked PropertyController to fetch all properties.");
     const res = await supabase
         .from('Properties')
         .select();
@@ -15,7 +14,6 @@ export const getAllProperties = async () => {
 }
 
 export const getProperty = async (propertyId: number) => {
-    alert("You have asked PropertyController to fetch a property.");
     const res = await supabase
         .from('Properties')
         .select()
@@ -26,7 +24,7 @@ export const getProperty = async (propertyId: number) => {
         throw (res.error || `Property id ${propertyId} not found.`);
     }
 
-    return res.data;
+    return res.data as Property;
 }
 
 export const createProperty = () => {

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -1,0 +1,201 @@
+import React from 'react'
+import styled from 'styled-components'
+import { addTask } from '../controllers/TaskController';
+
+const AddTaskPage = (props: { goBack: () => void }) => {
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        addTask();
+        props.goBack();
+    }
+
+    return (
+        <AddPropertyForm onSubmit={handleSubmit}>
+            {/* Row 0 */}
+            <GridItemCol1Span>
+                <h3> Add Task </h3>
+            </GridItemCol1Span>
+
+            {/* Row 1 */}
+            <GridItemCol1Span style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
+                Status
+                <StatusCheckbox type="checkbox" />
+            </GridItemCol1Span>
+
+            {/* Row 2 */}
+            <GridItemCol1>
+                <TitleAndText title="Name" name="name" />
+            </GridItemCol1>
+            <GridItemCol2>
+                <TitleAndText title="Due Date" name="date" />
+            </GridItemCol2>
+
+            {/* Row 3 */}
+            <GridItemCol1Span>
+                <TitleAndTextArea title="Description" name="description" />
+            </GridItemCol1Span>
+
+            {/* Row 4 */}
+            <GridItemCol1>
+                <TitleAndText title="Tags" name="" />
+            </GridItemCol1>
+            <GridItemCol2>
+                <TitleAndText title="Rooms" name="" />
+            </GridItemCol2>
+
+            {/* Row 5 */}
+            <SubmitButtonsContainer>
+                <SubmitButton type='submit'>
+                    Save
+                </SubmitButton>
+            </SubmitButtonsContainer>
+        </AddPropertyForm>
+    )
+}
+
+export default AddTaskPage
+
+
+const TitleAndText = (props: TitleAndInputProps) => {
+    return (
+        <label>
+            {props.title}
+            <TextInput name={props.name} type={props.type} style={props.style} />
+        </label>
+    )
+}
+
+const TitleAndTextArea = (props: TitleAndInputProps) => {
+    return (
+        <label>
+            {props.title}
+            <TextArea name={props.name} style={props.style} />
+        </label>
+    )
+}
+
+// const TitleAndFile = (props: TitleAndInputProps) => {
+//     return (
+//         <label>
+//             {props.title}
+//             <FileInputArea title={props.title} name={props.name} />
+//         </label>
+//     )
+// }
+
+interface TitleAndInputProps {
+    title: string;
+    name: string;
+    type?: string;
+    longText?: boolean;
+    style?: React.CSSProperties;
+}
+
+const TextInput = styled.input`
+    width: 100%;
+    margin: 10px 0px;
+    border: none;
+    border-radius: 5px;
+    background-color: #eeeeee;
+    padding: 10px;
+    box-sizing: border-box;
+    color: gray;
+    font-weight: bold;
+`
+
+const TextArea = styled.textarea`
+    width: 100%;
+    margin: 10px 0px;
+    border: none;
+    border-radius: 5px;
+    background-color: #eeeeee;
+    padding: 10px;
+    box-sizing: border-box;
+    color: gray;
+    font-weight: bold;
+    resize: none;
+    height: 100px;
+`
+
+// const FileInputArea = (props: TitleAndInputProps) => {
+//     return (
+//         <div>
+//             <input name={props.name} type="file" accept="image/*" id="input-file-upload" style={{ display: "none" }} />
+//             <FileInputDiv>
+//                 <label id="label-file-upload" htmlFor="input-file-upload" style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+//                     <img src={uploadImage} alt="upload icon" style={{ height: 25 }} />
+//                     <div style={{ textAlign: "center", margin: 5 }}> Drag & Drop </div>
+//                 </label>
+//             </FileInputDiv>
+//         </div>
+//     )
+// }
+
+const StatusCheckbox = styled.input`
+    border: 5px solid red;
+    height: 1.5rem;
+    width: 1.5rem;
+`
+
+// const FileInputDiv = styled.div`
+//     margin: 10px 0px;
+//     border-radius: 5px;
+//     background-color: #eeeeee;
+//     color: #a5a5a5;
+//     height: 100px;
+//     display: flex;
+//     justify-content: center;
+//     align-items: center;
+// `
+
+const AddPropertyForm = styled.form`
+    color: gray;
+    margin: 0px 30px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 0.5fr 0.3fr 0.5fr 0.5fr 0.5fr 0.3fr;
+    gap: 10px 20px;
+`
+
+const GridItemCol1 = styled.div`
+    grid-column-start: 1;
+`
+
+const GridItemCol2 = styled.div`
+    grid-column-start: 2;
+`
+
+const GridItemCol1Span = styled.div`
+    grid-column-start: 1;
+    grid-column-end: 3;
+`
+
+const SubmitButton = styled.button`
+    background-color: #e0f4dc;
+    color: #5f6f67;
+    font-weight: bold;
+    padding: 10px 30px;
+    margin: 5px 10px;
+    grid-column-start: 3;
+
+    //border
+    border: none;
+    border-radius: 10px;
+    transition: 0.3s ease-in-out;
+
+    // on hover cursor should change to a pointer
+    // and color should darken to indicate clickable
+    &:hover {
+        cursor: pointer;
+        background-color: #d0e4cc;
+    }
+`
+
+const SubmitButtonsContainer = styled.div`
+    display: flex;
+    align-items: end;
+    justify-content: end;
+    grid-column-start: 2;
+    margin: 0;
+`

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,7 +12,7 @@ const Home = () => {
     useEffect(() => {
         getAllProperties()
             .then((res) => setProperties(res))
-            .catch(err => console.log(err));
+            .catch(err => alert(err));
     }, []);
 
     return (

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -5,10 +5,12 @@ import house from "../assets/house.jpg";
 import addbuttonsvg from "../assets/plus-button.svg";
 import TaskViewButton from '../components/TaskViewButton';
 import Task from '../components/Task';
-import { useNavigate, useParams } from 'react-router';
+import { Route, Routes, useNavigate, useParams } from 'react-router';
 import { getTasksOfProperty } from '../controllers/TaskController';
 import { getProperty } from '../controllers/PropertyController';
 import { Property } from '../Types';
+import AddTaskPage from './AddTask';
+import Popup from '../components/Popup';
 
 const Page2 = () => {
 
@@ -42,36 +44,47 @@ const Page2 = () => {
     }, [params.id, navigate])
 
     return (
-        <TaskContainer>
-            <BackButtonContainer>
-                <BackButton src={backbuttonsvg}></BackButton>
-                <BackLabel>Back</BackLabel>
-            </BackButtonContainer>
-            <HouseContainer style={{ backgroundImage: `url(${property?.image_url})` }}>
-                <HouseImageOverlay></HouseImageOverlay>
-                <HouseLabel>
-                    {property?.address}
-                </HouseLabel>
-            </HouseContainer>
-            <FilterandSortContainer>
-                <TaskViewButton
-                    label="Filter"
-                    onClick={() => console.log("Filter button clicked")}
-                />
-                <TaskViewButton
-                    label="Sort"
-                    onClick={() => console.log("Sort button clicked")}
-                />
-                <AddButton src={addbuttonsvg}></AddButton>
-            </FilterandSortContainer>
-            <TaskListContainer>
-                <Task
-                    title="Task 1"
-                    due="Due 1"
-                    bg_color="#E1CAE8"
-                />
-            </TaskListContainer>
-        </TaskContainer>
+        <>
+            <TaskContainer>
+                <BackButtonContainer>
+                    <BackButton src={backbuttonsvg}></BackButton>
+                    <BackLabel>Back</BackLabel>
+                </BackButtonContainer>
+                <HouseContainer style={{ backgroundImage: `url(${property?.image_url})` }}>
+                    <HouseImageOverlay></HouseImageOverlay>
+                    <HouseLabel>
+                        {property?.address}
+                    </HouseLabel>
+                </HouseContainer>
+                <FilterandSortContainer>
+                    <TaskViewButton
+                        label="Filter"
+                        onClick={() => console.log("Filter button clicked")}
+                    />
+                    <TaskViewButton
+                        label="Sort"
+                        onClick={() => console.log("Sort button clicked")}
+                    />
+                    <AddButton src={addbuttonsvg} onClick={() => navigate("add")}></AddButton>
+                </FilterandSortContainer>
+                <TaskListContainer>
+                    <Task
+                        title="Task 1"
+                        due="Due 1"
+                        bg_color="#E1CAE8"
+                    />
+                </TaskListContainer>
+            </TaskContainer>
+            <Routes>
+                <Route path="add" element={
+                    <Popup
+                        onClickOutside={() => navigate("")}
+                        onKeyboardEsc={() => navigate("")}
+                        element={<AddTaskPage goBack={() => navigate("")} />}
+                    />
+                } />
+            </Routes>
+        </>
     )
 }
 


### PR DESCRIPTION
<!-- 
  Here is a template for PRs to help us get the workflow going.
  Anything in this style is a comment to help clarify the template; 
  it won't be included in the PR. -->

General description of changes:
* Adds AddTask popup (via the route `/property/<property-id>/add`)
* Removes some alerts for the controllers I've implemented
* Change the Properties page to display fetch error instead of log to console

Breaking changes: 
<!-- anything you changed that might break other parts of the website? 
    e.g. changing the format of something returned by a query -->
* None

Did you run `npm run before-pr`?
<!-- put an X to check the appropriate box -->
- [x] yes
- [ ] no

Does this PR fix/implement an Issue?
<!-- put an X to check the appropriate box
    if yes, replace XX with the number of the issue 
    (no space between # and the number. e.g. #13) -->
- [x] yes, fixes #17 
- [ ] no

