### PR TITLE
Fix UI (Properties boundary): fix property box height when it's on its own row

### DIFF
--- a/src/components/properties/NewPropertyCard.tsx
+++ b/src/components/properties/NewPropertyCard.tsx
@@ -24,7 +24,7 @@ const AddPropertyCard = styled.div`
     border: 3px solid #cbcbcb;
     border-radius: 10px;
     height: 100%;
-    max-height: 250px;
+    height: 250px;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
<!-- 
  Here is a template for PRs to help us get the workflow going.
  Anything in this style is a comment to help clarify the template; 
  it won't be included in the PR. -->

General description of changes:
* Fixes "Add Property" card height when it's on its own row

Breaking changes: 
<!-- anything you changed that might break other parts of the website? 
    e.g. changing the format of something returned by a query -->
* none

Did you run `npm run before-pr`?
<!-- put an X to check the appropriate box -->
- [x] yes
- [ ] no

Does this PR fix/implement an Issue?
<!-- put an X to check the appropriate box
    if yes, replace XX with the number of the issue 
    (no space between # and the number. e.g. #13) -->
- [ ] yes, fixes #XX
- [x] no (@bri-personal in the future pls make a bug report when you find stuff like this)


Before:
![image](https://github.com/MrEminent42/casamico/assets/10686417/429abb6e-7d66-4e71-9385-36023b21baa1)

Now:

![image](https://github.com/MrEminent42/casamico/assets/10686417/3ab1785c-86a0-4ade-9243-717127e824c3)
