### PR TITLE
UI: Back/Cancel buttons

### DIFF
--- a/src/pages/AddProperty.tsx
+++ b/src/pages/AddProperty.tsx
@@ -97,16 +97,22 @@ const AddProperty = () => {
             <GridItemCol12>
                 <TitleAndText title="Street Address" name="address" value={newProperty.address} handleChange={handleChange}/>
             </GridItemCol12>
-            <PreviewContainer>
-                <h3>Preview</h3>
-                <label style={{ marginTop: 10, marginBottom: 10 }}>Card View</label>
-                <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
-                    <PropertyCard
-                        property={newProperty}
-                        noPadding
-                    />
-                </div>
-            </PreviewContainer>
+            <PreviewAndSubmitContainer>
+                <PreviewContainer>
+                    <h3>Preview</h3>
+                    <label style={{ marginTop: 10, marginBottom: 10 }}>Card View</label>
+                    <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+                        <PropertyCard
+                            property={newProperty}
+                            noPadding
+                        />
+                    </div>
+                </PreviewContainer>
+                <SubmitButtonsContainer>
+                    <CancelButton onClick={() => navigate("/")}>Cancel</CancelButton>
+                    <SubmitButton type="submit">Save</SubmitButton>
+                </SubmitButtonsContainer>
+            </PreviewAndSubmitContainer>
             <GridItemCol1>
                 <TitleAndText title="City" name="city" value={newProperty.city} handleChange={handleChange} />
             </GridItemCol1>
@@ -122,11 +128,6 @@ const AddProperty = () => {
             <GridItemCol12>
                 <TitleAndText title="Rooms" name="rooms" value={newRooms} handleChange={handleRoomsChange} />
             </GridItemCol12>
-            <SubmitButtonsContainer>
-                <SubmitButton>
-                    Save
-                </SubmitButton>
-            </SubmitButtonsContainer>
         </AddPropertyForm>
     )
 }
@@ -228,6 +229,7 @@ const GridItemCol12 = styled.div`
 `
 
 const PreviewContainer = styled.div`
+    flex: 1;
     display: flex;
     flex-direction: column;
     margin: 0px auto;
@@ -238,8 +240,15 @@ const PreviewContainer = styled.div`
     //border: 1px dotted black;
 `
 
+const PreviewAndSubmitContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    grid-column-start: 3;
+    grid-row-start: 1;
+    grid-row-end: 6;
+`
+
 const SubmitButton = styled.button`
-    type: submit;
     background-color: #e0f4dc;
     color: #5f6f67;
     font-weight: bold;
@@ -262,11 +271,33 @@ const SubmitButton = styled.button`
     }
 `
 
+const CancelButton = styled.button`
+    background-color: #f4e0e0;
+    color: #6f5f5f;
+    font-weight: bold;
+    padding: 10px 30px;
+    margin: 5px 10px;
+
+    //border
+    border: none;
+    border-radius: 10px;
+    box-shadow: 2px 2px 10px rgba(0,0,0,0.1); 
+    transition: 0.3s ease-in-out;
+
+    // on hover, "raise" it by scaling the image up a bit, 
+    // and making more shadow.
+    // also, cursor should change to a pointer to indicate clickable
+    &:hover {
+        cursor: pointer;
+        background-color: #e4d0d0;
+    }
+`
+
+
 const SubmitButtonsContainer = styled.div`
     display: flex;
-    align-items: end;
-    justify-content: end;
-    grid-column-start: 3;
-    grid-row-start: 6;
-    //border: 1px dotted black;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    top: 76px;
 `

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -46,7 +46,7 @@ const Page2 = () => {
     return (
         <>
             <TaskContainer>
-                <BackButtonContainer>
+                <BackButtonContainer onClick={() => navigate("/")}>
                     <BackButton src={backbuttonsvg}></BackButton>
                     <BackLabel>Back</BackLabel>
                 </BackButtonContainer>
@@ -96,16 +96,19 @@ const TaskContainer = styled.div`
     padding-left: 35px;
 `
 
-const BackButtonContainer = styled.div`
+const BackButtonContainer = styled.button`
     display: flex;
     align-items: center;
     margin: 10px 10px 10px 0;
+    background: none;
+    border: none;
+    width: 100px;
+    cursor: pointer;
 `
 
 const BackButton = styled.img`
     width: 30px;
     height: 30px;
-    cursor: pointer;
 `
 
 const BackLabel = styled.p`

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -46,7 +46,7 @@ const Page2 = () => {
     return (
         <>
             <TaskContainer>
-                <BackButtonContainer onClick={() => navigate("/")}>
+                <BackButtonContainer>
                     <BackButton src={backbuttonsvg}></BackButton>
                     <BackLabel>Back</BackLabel>
                 </BackButtonContainer>
@@ -96,19 +96,16 @@ const TaskContainer = styled.div`
     padding-left: 35px;
 `
 
-const BackButtonContainer = styled.button`
+const BackButtonContainer = styled.div`
     display: flex;
     align-items: center;
     margin: 10px 10px 10px 0;
-    background: none;
-    border: none;
-    width: 100px;
-    cursor: pointer;
 `
 
 const BackButton = styled.img`
     width: 30px;
     height: 30px;
+    cursor: pointer;
 `
 
 const BackLabel = styled.p`


### PR DESCRIPTION
General description of changes:
* The back button on the tasks page now routes back to the home page. 
* There is now a cancel button on the add property page because I forgot to make a separate branch

Breaking changes: 
* None

Did you run `npm run before-pr`?
- [X] yes
- [ ] no

Does this PR fix/implement an Issue?
- [X] yes, fixes #35 
- [X] also fixes #42 
- [ ] no