### PR TITLE
TasksWithTags db updating on Task creation now

### DIFF
--- a/src/controllers/TasksWithTagsController.tsx
+++ b/src/controllers/TasksWithTagsController.tsx
@@ -13,5 +13,5 @@ export const addTaskWithTags = async (taskWithTag: Database['public']['Tables'][
     }
 
     // returns the newly created taskWithTag
-    return res.data as Database['public']['Tables']['TasksWithTags']['Row'];
+    return res.data;
 }

--- a/src/controllers/TasksWithTagsController.tsx
+++ b/src/controllers/TasksWithTagsController.tsx
@@ -1,0 +1,17 @@
+import { supabase } from "../supabase/db";
+import { Database } from "../supabase/supabase";
+
+export const addTaskWithTags = async (taskWithTag: Database['public']['Tables']['TasksWithTags']['Insert']) => {
+    const res = await supabase
+        .from('TasksWithTags')
+        .insert(taskWithTag)
+        .select()
+        .single();
+
+    if (res.error) {
+        throw res.error;
+    }
+
+    // returns the newly created taskWithTag
+    return res.data as Database['public']['Tables']['TasksWithTags']['Row'];
+}

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -107,11 +107,12 @@ const AddTask = (props: AddTaskProps) => {
 
         try {
             taskId = await addTask(task);
-            props.goBack();
         } catch (err) {
             console.log(err);
-            props.goBack();
+            alert("Error adding task.")
             return;
+        } finally {
+            props.goBack();
         }
 
         await Promise.all(selectedTags.map(async (tag) => {
@@ -122,6 +123,7 @@ const AddTask = (props: AddTaskProps) => {
             return await addTaskWithTags(taskWithTag);
         })).catch((err) => {
             console.log(err);
+            alert("Error adding tags to task.");
             props.goBack();
         })
     }

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -123,7 +123,6 @@ const AddTask = (props: AddTaskProps) => {
         })).catch((err) => {
             console.log(err);
             props.goBack();
-            return;
         })
     }
 

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -107,6 +107,7 @@ const AddTask = (props: AddTaskProps) => {
 
         try {
             taskId = await addTask(task);
+            props.goBack();
         } catch (err) {
             console.log(err);
             props.goBack();


### PR DESCRIPTION
General description of changes:
* Creating a task with tags now updates the TasksWithTags database

Breaking changes: 
* None I think, but I changed the logic for submitting a task (it now uses a try/catch block)

Did you run `npm run before-pr`?
- [X] yes
- [ ] no

Does this PR fix/implement an Issue?
- [X] yes, fixes #52 
- [ ] no
