### PR TITLE
Fix bug: require due date before accepting new task

### DIFF
--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -25,7 +25,6 @@ const AddTask = (props: AddTaskProps) => {
     const [dueDate, setDueDate] = useState("");
     const [done, setDone] = useState(false);
 
-    // const colors = ["ef4444", "f97316", "eab308", "84cc16", "10b981", "06b6d4", "3b82f6", "8b5cf6", "d946ef", "4b5563"]
     const [colors, setColors] = useState(() => {
         return [
             { color: "#fca5a5", selected: true },
@@ -81,6 +80,11 @@ const AddTask = (props: AddTaskProps) => {
 
         if (!selectedRoom) {
             alert("You must select a room.");
+            return;
+        }
+
+        if (!dueDate) {
+            alert("You must select a due date.");
             return;
         }
 


### PR DESCRIPTION
General description of changes:
* Adds requirement for due date to be selected before a task is created see #57

Breaking changes: 
<!-- anything you changed that might break other parts of the website? 
    e.g. changing the format of something returned by a query -->
* none

Did you run `npm run before-pr`?
<!-- put an X to check the appropriate box -->
- [x] yes
- [ ] no

Does this PR fix/implement an Issue?
<!-- put an X to check the appropriate box
    if yes, replace XX with the number of the issue 
    (no space between # and the number. e.g. #13) -->
- [x] yes, fixes #57 
- [ ] no
