### PR TITLE
Add Delete Property button on home page for each property card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2526,9 +2526,9 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.22.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
-      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
+      "version": "13.23.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -4165,10 +4165,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
-      "integrity": "sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==",
-      "peer": true,
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
+      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4180,14 +4179,13 @@
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@testing-library/dom/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4198,20 +4196,10 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-      "peer": true,
-      "dependencies": {
-        "deep-equal": "^2.0.5"
-      }
-    },
     "node_modules/@testing-library/dom/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4227,7 +4215,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4238,14 +4225,12 @@
     "node_modules/@testing-library/dom/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@testing-library/dom/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4254,7 +4239,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4359,96 +4343,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
-      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-      "dependencies": {
-        "deep-equal": "^2.0.5"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@testing-library/react/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -4577,9 +4471,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
-      "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/express": {
       "version": "4.17.18",
@@ -4838,9 +4732,9 @@
       }
     },
     "node_modules/@types/yargs": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.6.tgz",
-      "integrity": "sha512-oTP7/Q13GSPrgcwEwdlnkoZSQ1Hg9THe644qq8PG6hhJzjZ3qj1JjEFPIwWV/IXVs5XGIVqtkNOS9kh63WIJ+A==",
+      "version": "16.0.8",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.8.tgz",
+      "integrity": "sha512-1GwLEkmFafeb/HbE6pC7tFlgYSQ4Iqh2qlWCq8xN+Qfaiaxr2PcLfuhfRFRYqI6XJyeFoLYyKnhFbNsst9FMtQ==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -5227,9 +5121,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5446,11 +5340,11 @@
       }
     },
     "node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "dependencies": {
-        "dequal": "^2.0.3"
+        "deep-equal": "^2.0.5"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -8188,11 +8082,11 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
-      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -8421,9 +8315,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.22.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
-      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
+      "version": "13.23.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -9223,6 +9117,19 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -9323,14 +9230,14 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -9612,14 +9519,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/hpack.js/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -12091,9 +11990,9 @@
       }
     },
     "node_modules/jest-watch-typeahead/node_modules/@types/yargs": {
-      "version": "17.0.26",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.26.tgz",
-      "integrity": "sha512-Y3vDy2X6zw/ZCumcwLpdhM5L7jmyGpmBCTYMHDLqT2IKVMYRRLdv6ZakA+wxhra6Z/3bwhNbNl9bDGXaFU+6rw==",
+      "version": "17.0.31",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.31.tgz",
+      "integrity": "sha512-bocYSx4DI8TmdlvxqGpVNXOgCNR1Jj0gNPhhAY+iz1rgKDAaYrAYdFYnhDV1IFuiuVc9HkOwyDcFxaTElF3/wg==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -14356,9 +14255,9 @@
       }
     },
     "node_modules/postcss-load-config/node_modules/yaml": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
-      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "engines": {
         "node": ">= 14"
       }
@@ -15805,9 +15704,9 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
-      "version": "1.22.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
-      "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -16677,12 +16576,17 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -16939,25 +16843,6 @@
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/sucrase/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/supabase": {
@@ -17703,9 +17588,9 @@
       }
     },
     "node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
       }

--- a/src/components/Confirmation.tsx
+++ b/src/components/Confirmation.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components'
+
+interface ConfirmationProps {
+    confirmationText: string;
+    doConfirmed: (...args: any[]) => void;
+    goBack: () => void;
+}
+
+// generalized confirmation screen to be used in a Pop-up component.
+// assumes there is a parameter :id in the URL!
+const Confirmation = ({confirmationText, goBack, doConfirmed} : ConfirmationProps) => {
+    const params = useParams();
+
+    return (
+        <div style={{display: "flex", flexDirection: "column", alignItems: "center"} }>
+            <ConfirmationText>
+                {confirmationText}
+            </ConfirmationText>
+            <ButtonContainer>
+                <CancelButton
+                    onClick={goBack}>
+                    Cancel
+                </CancelButton>
+                <SubmitButton
+                    onClick={() => {
+                        if (params.id)
+                            doConfirmed(+params.id);
+                        else
+                            alert("No id provided");
+                            goBack();
+                        }
+                    }>
+                    Yes
+                </SubmitButton>
+            </ButtonContainer>
+        </div>
+    )
+}
+
+export default Confirmation
+
+const ConfirmationText = styled.div`
+    font-size: 20px;
+    font-weight: 600;
+    color: #4c4c4c;
+    text-align: center;
+    margin: 15px 15px;
+`
+
+const ButtonContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 10px;
+    width: 60%;
+    //border: 1px solid black;
+`
+
+const SubmitButton = styled.button`
+    background-color: #e0f4dc;
+    color: #5f6f67;
+    font-weight: bold;
+    padding: 10px 30px;
+    margin: 5px 10px;
+    min-width: 40%;
+
+    //border
+    border: none;
+    border-radius: 10px;
+    box-shadow: 2px 2px 10px rgba(0,0,0,0.1); 
+    transition: 0.3s ease-in-out;
+
+    // on hover, darken color
+    // also, cursor should change to a pointer to indicate clickable
+    &:hover {
+        cursor: pointer;
+        background-color: #d0e4cc;
+    }
+`
+
+const CancelButton = styled.button`
+    background-color: #f4e0e0;
+    color: #6f5f5f;
+    font-weight: bold;
+    padding: 10px 30px;
+    margin: 5px 10px;
+    min-width: 40%;
+
+    //border
+    border: none;
+    border-radius: 10px;
+    box-shadow: 2px 2px 10px rgba(0,0,0,0.1); 
+    transition: 0.3s ease-in-out;
+
+    // on hover, darken color
+    // also, cursor should change to a pointer to indicate clickable
+    &:hover {
+        cursor: pointer;
+        background-color: #e4d0d0;
+    }
+`

--- a/src/components/Confirmation.tsx
+++ b/src/components/Confirmation.tsx
@@ -25,11 +25,12 @@ const Confirmation = ({confirmationText, goBack, doConfirmed} : ConfirmationProp
                 </CancelButton>
                 <SubmitButton
                     onClick={() => {
-                        if (params.id)
-                            doConfirmed(+params.id);
-                        else
-                            alert("No id provided");
-                            goBack();
+                            if (params.id)
+                                doConfirmed(+params.id);
+                            else {
+                                alert("No id provided");
+                                goBack();
+                            }
                         }
                     }>
                     Yes

--- a/src/components/properties/NewPropertyCard.tsx
+++ b/src/components/properties/NewPropertyCard.tsx
@@ -19,10 +19,11 @@ const NewPropertyCard = () => {
 
 export default NewPropertyCard
 
-const AddPropertyCard = styled.div`
+const AddPropertyCard = styled.button`
     border: 3px solid #cbcbcb;
     border-radius: 10px;
-    height: 100%;
+    background: inherit;
+    width: 100%;
     height: 250px;
     display: flex;
     align-items: center;

--- a/src/components/properties/NewPropertyCard.tsx
+++ b/src/components/properties/NewPropertyCard.tsx
@@ -8,10 +8,9 @@ const NewPropertyCard = () => {
     let navigate = useNavigate();
 
     return (
-        <PropertyGridItemPadding
-            onClick={() => navigate("/add-property")}
-        >
-            <AddPropertyCard>
+        <PropertyGridItemPadding>
+            <AddPropertyCard
+                onClick={() => navigate("/add-property")}>
                 <AddIconImage src={addIcon} />
             </AddPropertyCard>
         </PropertyGridItemPadding>

--- a/src/components/properties/PropertyCard.tsx
+++ b/src/components/properties/PropertyCard.tsx
@@ -7,7 +7,6 @@ import { Database } from '../../supabase/supabase';
 import { displayError } from '../../App';
 import EditRoundedIcon from '@mui/icons-material/EditRounded';
 import DeleteForeverRoundedIcon from '@mui/icons-material/DeleteForeverRounded';
-import { deleteProperty } from '../../controllers/PropertyController';
 
 
 interface PropertyCardProps {
@@ -68,12 +67,11 @@ const PropertyCardContents = (props: PropertyCardProps) => {
                     </EditButtonDiv>
                 </EditButton>
                 <DeleteButton
-                    onClick={async (e: React.MouseEvent) => {
-                        await deleteProperty(props.property.property_id, props.property.image_url)
-                            .catch((error) => displayError(error, "delete property"));
+                    onClick={(e: React.MouseEvent) => {
+                        navigate("/delete-property/"+property_id);
                         e.stopPropagation();
-                        props.setRefresh(true);
-                    }}
+                        }
+                    }
                 >
                     <DeleteButtonDiv>
                         <DeleteForeverRoundedIcon htmlColor="#6f5f5f" />

--- a/src/components/properties/PropertyCard.tsx
+++ b/src/components/properties/PropertyCard.tsx
@@ -12,6 +12,8 @@ import { deleteProperty } from '../../controllers/PropertyController';
 
 interface PropertyCardProps {
     property: Database['public']['Tables']['Properties']['Row'];
+    refresh: boolean;
+    setRefresh: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const PropertyCard = (props: PropertyCardProps) => {
@@ -70,6 +72,7 @@ const PropertyCardContents = (props: PropertyCardProps) => {
                         await deleteProperty(props.property.property_id, props.property.image_url)
                             .catch((error) => displayError(error, "delete property"));
                         e.stopPropagation();
+                        props.setRefresh(true);
                     }}
                 >
                     <DeleteButtonDiv>

--- a/src/components/properties/PropertyCard.tsx
+++ b/src/components/properties/PropertyCard.tsx
@@ -196,6 +196,9 @@ const CardTitle = styled.div`
     margin: 5px 0px;
     color: #4c4c4c;
     text-align: left;
+    -ms-word-break: break-word;
+    word-break: break-word;
+    white-space: pre-wrap;
 `
 
 const CardText = styled.div`

--- a/src/components/properties/PropertyCard.tsx
+++ b/src/components/properties/PropertyCard.tsx
@@ -7,6 +7,7 @@ import { Database } from '../../supabase/supabase';
 import { displayError } from '../../App';
 import EditRoundedIcon from '@mui/icons-material/EditRounded';
 import DeleteForeverRoundedIcon from '@mui/icons-material/DeleteForeverRounded';
+import { deleteProperty } from '../../controllers/PropertyController';
 
 
 interface PropertyCardProps {
@@ -65,8 +66,9 @@ const PropertyCardContents = (props: PropertyCardProps) => {
                     </EditButtonDiv>
                 </EditButton>
                 <DeleteButton
-                    onClick={(e: React.MouseEvent) => {
-                        navigate("/edit-property/" + property_id);
+                    onClick={async (e: React.MouseEvent) => {
+                        await deleteProperty(props.property.property_id, props.property.image_url)
+                            .catch((error) => displayError(error, "delete property"));
                         e.stopPropagation();
                     }}
                 >

--- a/src/components/properties/PropertyCard.tsx
+++ b/src/components/properties/PropertyCard.tsx
@@ -136,9 +136,6 @@ const ButtonsContainer = styled.div`
     top: 85%;
     z-index: 1;
     right: 10px;
-
-    // cursor should change to a pointer to indicate clickable
-    cursor: pointer;
 `
 
 const EditButton = styled.button`
@@ -147,6 +144,9 @@ const EditButton = styled.button`
     border: none;
     padding: 0px;
     margin-right: 10px;
+
+    // cursor should change to a pointer to indicate clickable
+    cursor: pointer;
 `
 
 const EditButtonDiv = styled.div`
@@ -171,6 +171,9 @@ const DeleteButton = styled.button`
     border: none;
     padding: 0px;
     margin-left: 10px;
+
+    // cursor should change to a pointer to indicate clickable
+    cursor: pointer;
 `
 
 const DeleteButtonDiv = styled.div`

--- a/src/components/properties/PropertyCard.tsx
+++ b/src/components/properties/PropertyCard.tsx
@@ -6,6 +6,7 @@ import { getTasksOfProperty } from '../../controllers/TaskController';
 import { Database } from '../../supabase/supabase';
 import { displayError } from '../../App';
 import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import DeleteForeverRoundedIcon from '@mui/icons-material/DeleteForeverRounded';
 
 
 interface PropertyCardProps {
@@ -52,16 +53,28 @@ const PropertyCardContents = (props: PropertyCardProps) => {
                     </CardText>
                 </div>
             </PropertyCardContainer>
-            <EditButton
-                onClick={(e: React.MouseEvent) => {
-                    navigate("/edit-property/" + property_id);
-                    e.stopPropagation();
-                }}
-            >
-                <EditButtonDiv>
-                    <EditRoundedIcon htmlColor="#5f6f67" />
-                </EditButtonDiv>
-            </EditButton>
+            <ButtonsContainer>
+                <EditButton
+                    onClick={(e: React.MouseEvent) => {
+                        navigate("/edit-property/" + property_id);
+                        e.stopPropagation();
+                    }}
+                >
+                    <EditButtonDiv>
+                        <EditRoundedIcon htmlColor="#5f6f67" />
+                    </EditButtonDiv>
+                </EditButton>
+                <DeleteButton
+                    onClick={(e: React.MouseEvent) => {
+                        navigate("/edit-property/" + property_id);
+                        e.stopPropagation();
+                    }}
+                >
+                    <DeleteButtonDiv>
+                        <DeleteForeverRoundedIcon htmlColor="#6f5f5f" />
+                    </DeleteButtonDiv>
+                </DeleteButton>
+            </ButtonsContainer>
         </div>
     )
 }
@@ -110,11 +123,10 @@ const PropertyImageWrapper = styled.div`
     }
 `
 
-const EditButton = styled.button`
-    background: none;
-    border-radius: 5px;
-    border: none;
-    padding: 0px;
+const ButtonsContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: right;
 
     // layer edit button over the property card wrapper in parent div to avoid nesting buttons
     position: absolute;
@@ -124,6 +136,14 @@ const EditButton = styled.button`
 
     // cursor should change to a pointer to indicate clickable
     cursor: pointer;
+`
+
+const EditButton = styled.button`
+    background: none;
+    border-radius: 5px;
+    border: none;
+    padding: 0px;
+    margin-right: 10px;
 `
 
 const EditButtonDiv = styled.div`
@@ -139,6 +159,30 @@ const EditButtonDiv = styled.div`
 
     &:hover {
         background: #d0e4cc;
+    }
+`
+
+const DeleteButton = styled.button`
+    background: none;
+    border-radius: 5px;
+    border: none;
+    padding: 0px;
+    margin-left: 10px;
+`
+
+const DeleteButtonDiv = styled.div`
+    background: #f4e0e0;
+    border-radius: 7px;
+    box-shadow: 2px 2px 4px rgba(0,0,0,0.2);
+    width: 100%;
+    padding: 2px;
+    padding-bottom: 0px;
+    padding-right: 1px;
+
+    transition: 0.3s ease-in-out;
+
+    &:hover {
+        background: #e4d0d0;
     }
 `
 

--- a/src/components/properties/PropertyCard.tsx
+++ b/src/components/properties/PropertyCard.tsx
@@ -11,8 +11,6 @@ import DeleteForeverRoundedIcon from '@mui/icons-material/DeleteForeverRounded';
 
 interface PropertyCardProps {
     property: Database['public']['Tables']['Properties']['Row'];
-    refresh: boolean;
-    setRefresh: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const PropertyCard = (props: PropertyCardProps) => {

--- a/src/components/properties/PropertyCardPreview.tsx
+++ b/src/components/properties/PropertyCardPreview.tsx
@@ -25,7 +25,6 @@ export default PropertyCardPreview
 const PropertyCardContainer = styled.div`
     display: flex;
     flex-direction: column;
-    width: 100%;
 `
 const PropertyImage = styled.img`
     // prevent image from overflowing
@@ -56,6 +55,9 @@ const CardTitle = styled.div`
     font-weight: 600;
     margin: 5px 0px;
     color: #4c4c4c;
+    -ms-word-break: break-word;
+    word-break: break-word;
+    white-space: pre-wrap;
 `
 
 const CardText = styled.div`

--- a/src/controllers/PropertyController.tsx
+++ b/src/controllers/PropertyController.tsx
@@ -83,9 +83,14 @@ export const deleteProperty = async (property_id: number, image_url: string) => 
         throw (error);
     }
 
-    await deletePropertyPhoto(image_url.substring(image_url.lastIndexOf('/') + 1))
-        .catch(error => { throw (error) });
+    //delete property photo ONLY IF it is not the default
+    image_url = image_url.substring(image_url.lastIndexOf('/') + 1);
+    if (image_url !== "default_house.png") {
+        await deletePropertyPhoto(image_url)
+            .catch(error => { throw (error) });
+    }
 }
+    
 
 //store given file in the database Property Photos bucket
 export const storePropertyPhoto = async (photo: File) => {

--- a/src/controllers/PropertyController.tsx
+++ b/src/controllers/PropertyController.tsx
@@ -50,7 +50,7 @@ export const createProperty = async (property: Database['public']['Tables']['Pro
 }
 
 export const updateProperty = async (property: Database['public']['Tables']['Properties']['Update'], rooms: string) => {
-    //create new Property entry in database
+    //update Property entry in database
     if (property.property_id) {
         const { data, error } = await supabase
             .from('Properties')
@@ -73,8 +73,18 @@ export const updateProperty = async (property: Database['public']['Tables']['Pro
     throw new Error("No property id was given");
 }
 
-export const deleteProperty = () => {
-    alert("You have asked PropertyController to delete a property.");
+export const deleteProperty = async (property_id: number, image_url: string) => {
+    const { error } = await supabase
+        .from('Properties')
+        .delete()
+        .eq('property_id', property_id);
+
+    if (error) {
+        throw (error);
+    }
+
+    await deletePropertyPhoto(image_url.substring(image_url.lastIndexOf('/') + 1))
+        .catch(error => { throw (error) });
 }
 
 //store given file in the database Property Photos bucket

--- a/src/pages/AddEditProperty.tsx
+++ b/src/pages/AddEditProperty.tsx
@@ -177,7 +177,7 @@ const AddEditProperty = (props: AddEditPropertyProps) => {
                 <TitleAndFile title="Upload Photo" name="photo" handleChange={uploadFile} />
             </GridItemCol12>
             <GridItemCol12>
-                <TitleAndText title="Rooms" name="rooms" value={newRooms} handleChange={handleRoomsChange} />
+                <TitleAndText title="Rooms Names" name="rooms" value={newRooms} handleChange={handleRoomsChange} />
             </GridItemCol12>
             <PreviewAndSubmitContainer>
                 <PreviewContainer>

--- a/src/pages/AddEditProperty.tsx
+++ b/src/pages/AddEditProperty.tsx
@@ -323,8 +323,7 @@ const SubmitButton = styled.button`
     box-shadow: 2px 2px 10px rgba(0,0,0,0.1); 
     transition: 0.3s ease-in-out;
 
-    // on hover, "raise" it by scaling the image up a bit, 
-    // and making more shadow.
+    // on hover, darken color
     // also, cursor should change to a pointer to indicate clickable
     &:hover {
         cursor: pointer;
@@ -345,8 +344,7 @@ const CancelButton = styled.button`
     box-shadow: 2px 2px 10px rgba(0,0,0,0.1); 
     transition: 0.3s ease-in-out;
 
-    // on hover, "raise" it by scaling the image up a bit, 
-    // and making more shadow.
+    // on hover, darken color
     // also, cursor should change to a pointer to indicate clickable
     &:hover {
         cursor: pointer;

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -273,7 +273,7 @@ const TextArea = styled.textarea`
     color: gray;
     font-weight: bold;
     resize: none;
-    height: 100px;
+    height: 50px;
 `
 
 const StatusCheckbox = styled.input`
@@ -287,7 +287,7 @@ const AddPropertyForm = styled.form`
     margin: 0px 30px;
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-template-rows: 3rem 3rem 5rem 5rem 5rem 9rem;
+    grid-template-rows: 3rem 3rem 5rem 5rem 5rem 6rem;
     gap: 10px 20px;
     width: 700px;
     height: 85vh;
@@ -341,7 +341,6 @@ const ColorPickerContainer = styled.div`
     justify-content: space-between;
     align-items: center;
     margin: 10px 0px;
-
 `
 
 const DropdownStyles = {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -40,6 +40,8 @@ const Home = () => {
                         <PropertyCard
                             property={property}
                             key={property.property_id}
+                            refresh={refresh}
+                            setRefresh={setRefresh }
                         />
                     ))
                 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,11 +3,12 @@ import { Route, Routes, useNavigate } from 'react-router';
 import PropertyCard from '../components/properties/PropertyCard';
 import NewPropertyCard from '../components/properties/NewPropertyCard'
 import styled from 'styled-components';
-import { getAllProperties } from '../controllers/PropertyController';
+import { deleteProperty, getAllProperties, getProperty } from '../controllers/PropertyController';
 import { Database } from '../supabase/supabase';
 import { displayError } from '../App';
 import Popup from '../components/Popup';
 import AddProperty from './AddEditProperty';
+import Confirmation from '../components/Confirmation';
 
 const Home = () => {
     const [properties, setProperties] = useState<Database['public']['Tables']['Properties']['Row'][]>([]);
@@ -64,6 +65,28 @@ const Home = () => {
                         element={<AddProperty goBack={
                             homeGoBack
                         } />}
+                    />
+                } />
+                <Route path="delete-property/:id/*" element={
+                    <Popup
+                        onClickOutside={homeGoBack}
+                        onKeyboardEsc={homeGoBack}
+                        element={<Confirmation
+                            confirmationText="Are you sure you want to delete this property?"
+                            goBack={homeGoBack}
+                            doConfirmed={
+                                async (id: number) => {
+                                    await getProperty(id)
+                                        .then(async (res) => {
+                                            await deleteProperty(id, res.image_url)
+                                                .catch((error) => displayError(error, "delete property"));
+                                        })
+                                        .catch((error) => displayError(error, "get property when deleting property"));
+                                   
+                                    homeGoBack();
+                                }
+                            }
+                        />}
                     />
                 } />
             </Routes>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -41,8 +41,6 @@ const Home = () => {
                         <PropertyCard
                             property={property}
                             key={property.property_id}
-                            refresh={refresh}
-                            setRefresh={setRefresh }
                         />
                     ))
                 }


### PR DESCRIPTION
<!-- 
  Here is a template for PRs to help us get the workflow going.
  Anything in this style is a comment to help clarify the template; 
  it won't be included in the PR. -->

General description of changes:
* Adds delete property button for each property card on home page, and confirmation component that appears in pop-up to confirm deletion when the button is pressed
* Fixes cursor not looking like pointer on edit button in property card (and in new delete button)

Breaking changes: 
<!-- anything you changed that might break other parts of the website? 
    e.g. changing the format of something returned by a query -->
* none

Did you run `npm run before-pr`?
<!-- put an X to check the appropriate box -->
- [X] yes
- [ ] no

Does this PR fix/implement an Issue?
<!-- put an X to check the appropriate box
    if yes, replace XX with the number of the issue 
    (no space between # and the number. e.g. #13) -->
- [X] yes, fixes #69 and fixes #68 
- [ ] no

Other notes:

<!-- nice! now you can go ahead and create the PR -->
